### PR TITLE
[review] クラスベースのAPIに見直し

### DIFF
--- a/lib/dekiru/data_migration.rb
+++ b/lib/dekiru/data_migration.rb
@@ -2,6 +2,7 @@
 
 require_relative "data_migration/version"
 require_relative "data_migration/transaction_provider"
+require_relative "data_migration/migration"
 require_relative "data_migration_operator"
 
 module Dekiru

--- a/lib/dekiru/data_migration/migration.rb
+++ b/lib/dekiru/data_migration/migration.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Dekiru
+  module DataMigration
+    # Base class for data migration with testable method separation
+    class Migration
+      def self.run(options = {})
+        migration = new
+        title = migration.title
+
+        Operator.execute(title, options) do
+          migration.instance_variable_set(:@operator_context, self)
+          migration.migrate
+        end
+      end
+
+      def title
+        self.class.name.demodulize.underscore.humanize
+      end
+
+      def migrate
+        targets = migration_targets
+
+        log "Target count: #{targets.count}"
+        confirm?
+
+        find_each_with_progress(targets) do |record|
+          migrate_record(record)
+        end
+
+        log "Migration completed"
+      end
+
+      def migration_targets
+        raise NotImplementedError, "#{self.class}#migration_targets must be implemented"
+      end
+
+      def migrate_record(record)
+        raise NotImplementedError, "#{self.class}#migrate_record must be implemented"
+      end
+
+      private
+
+      def confirm?
+        if @operator_context
+          @operator_context.send(:confirm?)
+        else
+          # Default behavior during test (no confirmation)
+          puts "Confirmation skipped in test mode"
+        end
+      end
+
+      def log(message)
+        if @operator_context
+          @operator_context.send(:log, message)
+        else
+          # Default behavior during test
+          puts message
+        end
+      end
+
+      def find_each_with_progress(scope, options = {}, &block)
+        if @operator_context
+          @operator_context.send(:find_each_with_progress, scope, options, &block)
+        else
+          # Default behavior during test (no progress bar)
+          scope.find_each(&block)
+        end
+      end
+
+      def each_with_progress(enum, options = {}, &block)
+        if @operator_context
+          @operator_context.send(:each_with_progress, enum, options, &block)
+        else
+          # Default behavior during test (no progress bar)
+          enum.each(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/maintenance_script/maintenance_script_generator.rb
+++ b/lib/generators/maintenance_script/maintenance_script_generator.rb
@@ -14,8 +14,11 @@ class MaintenanceScriptGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
 
   def copy_maintenance_script_file
+    @filename_date = filename_date
+    @class_name = "#{name.classify}#{@filename_date}"
+
     template "maintenance_script.rb.erb",
-             "#{Dekiru::DataMigration.configuration.maintenance_script_directory}/#{filename_date}_#{file_name}.rb"
+             "#{Dekiru::DataMigration.configuration.maintenance_script_directory}/#{@filename_date}_#{file_name}.rb"
   end
 
   private

--- a/lib/generators/maintenance_script/templates/maintenance_script.rb.erb
+++ b/lib/generators/maintenance_script/templates/maintenance_script.rb.erb
@@ -2,6 +2,20 @@
 
 using Dekiru::DataMigration::DangerousMethodGuard
 
-Dekiru::DataMigration::Operator.execute('<%= @name %>') do
-  # write here
+class <%= @class_name %> < Dekiru::DataMigration::Migration
+  def title
+    '<%= @name %>'
+  end
+
+  def migration_targets
+    # Define ActiveRecord::Relation that returns the target migration
+    # User.where(some_condition: true)
+  end
+
+  def migrate_record(record)
+    # Define the update process for individual records
+    # user.update!(some_attribute: new_value)
+  end
 end
+
+<%= @class_name %>.run if __FILE__ == $PROGRAM_NAME

--- a/sig/dekiru/data_migration/migration.rbs
+++ b/sig/dekiru/data_migration/migration.rbs
@@ -1,0 +1,23 @@
+module Dekiru
+  module DataMigration
+    class Migration
+      def self.run: (?Hash[Symbol, untyped] options) -> bool
+
+      def title: () -> String
+
+      def migrate: () -> void
+
+      def migration_targets: () -> untyped
+
+      def migrate_record: (untyped record) -> void
+
+      private
+
+      def log: (String message) -> void
+
+      def find_each_with_progress: (untyped scope, ?Hash[Symbol, untyped] options) { (untyped) -> void } -> void
+
+      def each_with_progress: [T] (Enumerable[T] enum, ?Hash[Symbol, untyped] options) { (T) -> void } -> void
+    end
+  end
+end

--- a/spec/dekiru/data_migration/migration_spec.rb
+++ b/spec/dekiru/data_migration/migration_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ostruct"
+
+# テスト用のダミークラス
+class TestMigration < Dekiru::DataMigration::Migration
+  attr_reader :targets, :migrated_records
+
+  def initialize
+    super
+    @targets = (1..3).to_a.map { |i| OpenStruct.new(id: i) }
+    @migrated_records = []
+  end
+
+  def migration_targets
+    # テスト用のスコープをシミュレート
+    scope = OpenStruct.new(count: @targets.size)
+
+    # find_eachメソッドをオーバーライド
+    scope.define_singleton_method(:find_each) do |&block|
+      @targets.each(&block)
+    end
+
+    scope.instance_variable_set(:@targets, @targets)
+    scope
+  end
+
+  def migrate_record(record)
+    @migrated_records << record
+  end
+end
+
+RSpec.describe Dekiru::DataMigration::Migration do # rubocop:disable Metrics/BlockLength
+  let(:migration) { TestMigration.new }
+
+  describe ".run" do
+    it "Operator.executeを呼び出してmigrateを実行する" do
+      allow(Dekiru::DataMigration::Operator).to receive(:execute)
+        .with("Test migration", {})
+        .and_yield
+
+      # migrateメソッドの呼び出しを確認
+      expect_any_instance_of(TestMigration).to receive(:migrate)
+
+      TestMigration.run
+    end
+
+    it "オプションをOperator.executeに渡す" do
+      options = { warning_side_effects: false }
+      expect(Dekiru::DataMigration::Operator).to receive(:execute)
+        .with("Test migration", options)
+
+      TestMigration.run(options)
+    end
+  end
+
+  describe "#title" do
+    it "クラス名から適切なタイトルを生成する" do
+      expect(migration.title).to eq("Test migration")
+    end
+  end
+
+  describe "#migrate" do
+    it "migration_targetsを呼び出してログを出力する" do
+      allow(migration).to receive(:log)
+      allow(migration).to receive(:find_each_with_progress).and_call_original
+
+      migration.migrate
+
+      expect(migration.migrated_records.size).to eq(3)
+    end
+  end
+
+  describe "#migration_targets" do
+    it "基底クラスでは NotImplementedError を投げる" do
+      base_migration = described_class.new
+      expect { base_migration.migration_targets }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#migrate_record" do
+    it "基底クラスでは NotImplementedError を投げる" do
+      base_migration = described_class.new
+      record = OpenStruct.new(id: 1)
+      expect { base_migration.migrate_record(record) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "テスト時のデフォルト動作" do
+    describe "#log" do
+      it "putsを呼び出す" do
+        expect { migration.send(:log, "test message") }.to output("test message\n").to_stdout
+      end
+    end
+
+    describe "#find_each_with_progress" do
+      it "プログレスバーなしでfind_eachを呼び出す" do
+        scope = migration.migration_targets
+        results = []
+
+        migration.send(:find_each_with_progress, scope) do |record|
+          results << record
+        end
+
+        expect(results.size).to eq(3)
+      end
+    end
+
+    describe "#each_with_progress" do
+      it "プログレスバーなしでeachを呼び出す" do
+        enum = [1, 2, 3]
+        results = []
+
+        migration.send(:each_with_progress, enum) do |item|
+          results << item
+        end
+
+        expect(results).to eq([1, 2, 3])
+      end
+    end
+  end
+end


### PR DESCRIPTION
これまでのブロックAPIには何も変更を加えずに、新規はテスタブルなクラスAPIで記述できるように。

```ruby
# scripts/20230118_demo_migration.rb
class DemoMigration20230118 < Dekiru::DataMigration::Migration
  def migration_targets
    User.where("email LIKE '%sonicgarden%'").where(admin: false)
  end

  def migrate_record(user)
    user.update!(admin: true)
  end

  def migrate
    super
    log "Updated user count: #{User.where(admin: true).count}"
  end
end

DemoMigration20230118.run if __FILE__ == $PROGRAM_NAME
```