### PR TITLE
[review] fix: pass batch count as total to progress bar in migrate_in_batches

### DIFF
--- a/lib/dekiru/data_migration/migration.rb
+++ b/lib/dekiru/data_migration/migration.rb
@@ -4,6 +4,9 @@ module Dekiru
   module DataMigration
     # Base class for data migration with testable method separation
     class Migration
+      # Default batch size used by ActiveRecord's `in_batches` when `of:` is not given
+      DEFAULT_BATCH_SIZE = 1000
+
       attr_accessor :batch_size
 
       def self.run(options = {})
@@ -26,11 +29,12 @@ module Dekiru
       def migrate
         targets = migration_targets
 
-        log "Target count: #{targets.count}"
+        target_count = targets.count
+        log "Target count: #{target_count}"
         confirm?
 
         if migrate_batch_overridden?
-          migrate_in_batches(targets)
+          migrate_in_batches(targets, target_count)
         else
           migrate_each_record(targets)
         end
@@ -52,9 +56,11 @@ module Dekiru
 
       private
 
-      def migrate_in_batches(targets)
+      def migrate_in_batches(targets, target_count)
+        size = batch_size || DEFAULT_BATCH_SIZE
         batches = batch_size ? targets.in_batches(of: batch_size) : targets.in_batches
-        each_with_progress(batches) do |batch|
+        total = (target_count.to_f / size).ceil
+        each_with_progress(batches, total: total) do |batch|
           migrate_batch(batch)
         end
       end

--- a/spec/dekiru/data_migration/migration_spec.rb
+++ b/spec/dekiru/data_migration/migration_spec.rb
@@ -146,6 +146,33 @@ RSpec.describe Dekiru::DataMigration::Migration do # rubocop:disable Metrics/Blo
     end
   end
 
+  describe "#migrate (batch path progress total)" do
+    let(:batch_migration) { BatchTestMigration.new }
+
+    def capture_each_with_progress
+      received = nil
+      allow(batch_migration).to receive(:each_with_progress) do |enum, options = {}, &blk|
+        received = options
+        enum.each(&blk) # Preserve the original behavior (migrated_batches consistency)
+      end
+      yield
+      received
+    end
+
+    it "passes batch count as total to each_with_progress" do
+      allow(batch_migration).to receive(:log)
+      batch_migration.batch_size = 2 # ceil(3/2) => 2
+      opts = capture_each_with_progress { batch_migration.migrate }
+      expect(opts[:total]).to eq(2)
+    end
+
+    it "uses the default batch size (1000) for total when batch_size is not set" do
+      allow(batch_migration).to receive(:log)
+      opts = capture_each_with_progress { batch_migration.migrate } # ceil(3/1000) => 1
+      expect(opts[:total]).to eq(1)
+    end
+  end
+
   describe "#migrate (batch_size)" do
     let(:batch_migration) { BatchTestMigration.new }
 

--- a/spec/dekiru/data_migration/operator_spec.rb
+++ b/spec/dekiru/data_migration/operator_spec.rb
@@ -51,6 +51,20 @@ class ActiveRecord::Base # rubocop:disable Style/ClassAndModuleChildren
   end
 end
 
+# Mimics ActiveRecord::Batches::BatchEnumerator, which is Enumerable but does NOT respond to #size.
+class Dekiru::DummyBatchEnumerator # rubocop:disable Style/ClassAndModuleChildren
+  include Enumerable
+
+  def initialize(batches)
+    @batches = batches
+  end
+
+  def each(&block)
+    @batches.each(&block)
+  end
+  # Intentionally does not define #size, to reproduce the NoMethodError from BatchEnumerator.
+end
+
 RSpec.describe Dekiru::DataMigration::Operator do
   let(:dummy_stream) do
     Dekiru::DummyStream.new
@@ -193,6 +207,36 @@ RSpec.describe Dekiru::DataMigration::Operator do
       expect(operator.stream.out).to include("pass total as option:")
       expect(operator.stream.out).to include("Finished successfully:")
       expect(operator.stream.out).to include("Total time:")
+    end
+
+    it "uses the given total (percent format) even when the enum has no size" do
+      allow($stdin).to receive(:gets) { "yes\n" }
+      enum = Dekiru::DummyBatchEnumerator.new([[1, 2], [3]])
+
+      # Passing total: bypasses the enum.size lookup, so a size-less enum like
+      # ActiveRecord's BatchEnumerator gets a real percentage format ("%p%%"), not "??%".
+      expect(ProgressBar).to receive(:create)
+        .with(hash_including(total: 2, format: "%a |%b>>%i| %p%% %t"))
+        .and_call_original
+
+      operator.execute do
+        each_with_progress(enum, title: "batches", total: 2) { |_batch| }
+      end
+    end
+
+    it "falls back to the ??% format when size is unavailable and no total is given" do
+      allow($stdin).to receive(:gets) { "yes\n" }
+      enum = Dekiru::DummyBatchEnumerator.new([[1, 2], [3]])
+
+      # enum.size raises NoMethodError -> total stays nil -> "??%" format.
+      # This characterizes why migrate_in_batches must pass total: explicitly.
+      expect(ProgressBar).to receive(:create)
+        .with(hash_including(total: nil, format: "%a |%b>>%i| ??%% %t"))
+        .and_call_original
+
+      operator.execute do
+        each_with_progress(enum, title: "batches") { |_batch| }
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Fix the progress bar showing `??%` in `migrate_in_batches`: `BatchEnumerator` does not respond to `#size`, so `each_with_progress` fell back to `total=nil` and used the `??%` format.
- Pre-calculate `target_count` in `migrate` and pass it to `migrate_in_batches`, deriving `total = (target_count / size).ceil` and passing it explicitly as `total:` to `each_with_progress` (bypassing the `enum.size` lookup).
- Add a `DEFAULT_BATCH_SIZE = 1000` constant (mirrors ActiveRecord's `in_batches` default) used for the total calculation when `batch_size` is not set, plus a `DummyBatchEnumerator` test double that reproduces the missing `#size`, and regression tests.