### PR TITLE
[review] feat: deprecate Operator.execute in favor of Migration subclass

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,4 @@ Style/StringLiteralsInInterpolation:
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
+    - "*.gemspec"

--- a/README.md
+++ b/README.md
@@ -32,27 +32,9 @@ Or install it yourself as:
 $ gem install dekiru-data_migration
 ```
 
-## Data Migration Operator
+## Data Migration Class
 
-You can implement the necessary processing for data migration tasks with scripts like the following:
-
-```ruby
-# scripts/demo.rb
-Dekiru::DataMigration::Operator.execute('Grant admin privileges to users') do
-  targets = User.where("email LIKE '%sonicgarden%'")
-
-  log "Target user count: #{targets.count}"
-  find_each_with_progress(targets) do |user|
-    user.update!(admin: true)
-  end
-
-  log "Updated user count: #{User.where("email LIKE '%sonicgarden%'").where(admin: true).count}"
-end
-```
-
-## Data Migration Class (Recommended)
-
-You can also define migration logic as a class, which makes testing easier:
+Define migration logic as a class:
 
 ```ruby
 # scripts/20230118_demo_migration.rb
@@ -93,20 +75,6 @@ class DeactivateStaleUsersMigration < Dekiru::DataMigration::Migration
 end
 
 DeactivateStaleUsersMigration.run
-```
-
-If you use the block-based `Operator` directly, pass `in_batches` to `each_with_progress`:
-
-```ruby
-# scripts/deactivate_stale_users.rb
-Dekiru::DataMigration::Operator.execute('Deactivate stale users') do
-  targets = User.where(active: true).where("last_login_at < ?", 1.year.ago)
-
-  log "Target user count: #{targets.count}"
-  each_with_progress(targets.in_batches) do |batch|
-    batch.update_all(active: false)
-  end
-end
 ```
 
 #### Specifying the batch size
@@ -164,12 +132,10 @@ Total time: 6.35 sec
 
 ## Side Effect Monitoring
 
-By executing with the `warning_side_effects: true` option, side effects that occur during data migration tasks (database writes, job enqueuing, email sending, etc.) will be displayed.
+By passing `warning_side_effects: true` to `run`, side effects that occur during data migration tasks (database writes, job enqueuing, email sending, etc.) will be displayed.
 
 ```ruby
-Dekiru::DataMigration::Operator.execute('Grant admin privileges to users', warning_side_effects: true) do
-  # Processing content...
-end
+DemoMigration.run(warning_side_effects: true)
 ```
 
 Execution result:
@@ -208,30 +174,19 @@ Generated file example:
 
 class DemoMigration < Dekiru::DataMigration::Migration
   def migration_targets
-    # 移行対象を返すActiveRecord::Relationを定義
-    # 例: User.where(some_condition: true)
+    # Return an ActiveRecord::Relation of records to migrate
+    # e.g. User.where(some_condition: true)
     raise NotImplementedError, 'migration_targets method must be implemented'
   end
 
   def migrate_record(record)
-    # 個別レコードの更新処理を定義
-    # 例: record.update!(some_attribute: new_value)
+    # Define the update logic for each record
+    # e.g. record.update!(some_attribute: new_value)
     raise NotImplementedError, 'migrate_record method must be implemented'
   end
 end
 
 DemoMigration.run
-```
-
-### Legacy Block-based Approach
-
-For backward compatibility, you can still use the block-based approach:
-
-```ruby
-# scripts/legacy_demo.rb
-Dekiru::DataMigration::Operator.execute('demo_migration') do
-  # write here
-end
 ```
 
 ### Output Directory Configuration
@@ -311,10 +266,10 @@ end
 
 ### Runtime Options
 
+Pass options to `Migration.run`:
+
 ```ruby
-Dekiru::DataMigration::Operator.execute('Title', options) do
-  # Processing content
-end
+DemoMigration.run(warning_side_effects: true, without_transaction: false)
 ```
 
 Available options:

--- a/dekiru-data_migration.gemspec
+++ b/dekiru-data_migration.gemspec
@@ -19,9 +19,6 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/SonicGarden/dekiru-data_migration"
   spec.metadata["changelog_uri"] = "https://github.com/SonicGarden/dekiru-data_migration/releases"
-
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   gemspec = File.basename(__FILE__)
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
@@ -33,10 +30,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
   spec.add_dependency "rails"
   spec.add_dependency "ruby-progressbar"
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
 end

--- a/lib/dekiru/data_migration/migration.rb
+++ b/lib/dekiru/data_migration/migration.rb
@@ -16,7 +16,7 @@ module Dekiru
         options = options.dup
         migration.batch_size = options.delete(:batch_size)
 
-        Operator.execute(title, options) do
+        Operator.new(title, options).execute do
           migration.instance_variable_set(:@operator_context, self)
           migration.migrate
         end

--- a/lib/dekiru/data_migration/operator.rb
+++ b/lib/dekiru/data_migration/operator.rb
@@ -12,7 +12,13 @@ module Dekiru
 
       attr_reader :title, :stream, :logger, :result, :canceled, :started_at, :ended_at, :error
 
+      DEPRECATOR = ActiveSupport::Deprecation.new("2.0", "Dekiru::DataMigration")
+
       def self.execute(title, options = {}, &block)
+        DEPRECATOR.warn(
+          "Dekiru::DataMigration::Operator.execute is deprecated and will be removed in 2.0. " \
+          "Use Dekiru::DataMigration::Migration subclass instead."
+        )
         new(title, options).execute(&block)
       end
 

--- a/spec/dekiru/data_migration/migration_spec.rb
+++ b/spec/dekiru/data_migration/migration_spec.rb
@@ -62,7 +62,7 @@ class BatchTestMigration < Dekiru::DataMigration::Migration
   end
 end
 
-RSpec.describe Dekiru::DataMigration::Migration do # rubocop:disable Metrics/BlockLength
+RSpec.describe Dekiru::DataMigration::Migration do
   let(:migration) { TestMigration.new }
 
   describe ".run" do

--- a/spec/dekiru/data_migration/migration_spec.rb
+++ b/spec/dekiru/data_migration/migration_spec.rb
@@ -66,35 +66,36 @@ RSpec.describe Dekiru::DataMigration::Migration do # rubocop:disable Metrics/Blo
   let(:migration) { TestMigration.new }
 
   describe ".run" do
-    it "calls Operator.execute and runs migrate" do
-      allow(Dekiru::DataMigration::Operator).to receive(:execute)
-        .with("Test migration", {})
-        .and_yield
+    let(:operator) { instance_double(Dekiru::DataMigration::Operator, execute: nil) }
 
-      # Verify that migrate is called
-      expect_any_instance_of(TestMigration).to receive(:migrate)
+    before do
+      allow(Dekiru::DataMigration::Operator).to receive(:new).and_return(operator)
+    end
+
+    it "instantiates Operator with title and options and calls execute" do
+      expect(Dekiru::DataMigration::Operator).to receive(:new).with("Test migration", {}).and_return(operator)
+      expect(operator).to receive(:execute)
 
       TestMigration.run
     end
 
-    it "passes options to Operator.execute" do
+    it "passes options to Operator.new" do
       options = { warning_side_effects: false }
-      expect(Dekiru::DataMigration::Operator).to receive(:execute)
-        .with("Test migration", options)
+      expect(Dekiru::DataMigration::Operator).to receive(:new).with("Test migration", options).and_return(operator)
 
       TestMigration.run(options)
     end
 
-    it "extracts batch_size from the options before passing them to Operator.execute" do
-      # batch_size is consumed by Migration, so Operator.execute must not see it
-      expect(Dekiru::DataMigration::Operator).to receive(:execute)
+    it "extracts batch_size from the options before passing them to Operator.new" do
+      # batch_size is consumed by Migration, so Operator must not see it
+      expect(Dekiru::DataMigration::Operator).to receive(:new)
         .with("Test migration", { warning_side_effects: false })
+        .and_return(operator)
 
       TestMigration.run(batch_size: 500, warning_side_effects: false)
     end
 
     it "assigns batch_size to the migration instance" do
-      allow(Dekiru::DataMigration::Operator).to receive(:execute)
       assigned = nil
       allow_any_instance_of(TestMigration).to receive(:batch_size=) { |_, value| assigned = value }
 

--- a/spec/dekiru/data_migration/operator_spec.rb
+++ b/spec/dekiru/data_migration/operator_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
 require "spec_helper"
 
 class Dekiru::DummyStream # rubocop:disable Style/ClassAndModuleChildren
@@ -317,4 +316,3 @@ RSpec.describe Dekiru::DataMigration::Operator do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
- Add `ActiveSupport::Deprecation` warning to `Operator.execute`, marking it for removal in 2.0
- `Migration.run` now calls `Operator.new(...).execute` directly to avoid triggering the warning on internal use; a shared `DEPRECATOR` constant avoids allocating a new deprecator on each call
